### PR TITLE
chore: update GitHub org references (Cognitive-Creators-AI -> aetheronhq)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ on:
 
 jobs:
   sync-radar:
-    uses: Cognitive-Creators-AI/shared-ci-workflows/.github/workflows/sync-org-cursor-rules.yml@main
+    uses: aetheronhq/shared-ci-workflows/.github/workflows/sync-org-cursor-rules.yml@main
     permissions:
       contents: write
       pull-requests: write

--- a/public/action-setup.md
+++ b/public/action-setup.md
@@ -17,7 +17,7 @@ on:
 
 jobs:
   sync-radar:
-    uses: Cognitive-Creators-AI/shared-ci-workflows/.github/workflows/sync-org-cursor-rules.yml@main
+    uses: aetheronhq/shared-ci-workflows/.github/workflows/sync-org-cursor-rules.yml@main
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
Automated update for 2 file(s) referenced by git-owner-locations-github.tsv.

Changes:
- Replace Cognitive-Creators-AI with aetheronhq in common URL/token forms
- Update ghcr/docker registry owner
- Update GitHub Actions uses: references